### PR TITLE
Updating the readme to correct the action name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: bubkoo/label-commands@v1
+      - uses: bubkoo/potential-duplicates@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Label to set, when potential duplicates are detected.


### PR DESCRIPTION
A trivial change, but I spent 20 mins trying to figure out why the default example in the README wasn't working till I finally saw that the action name was incorrect. I understand that the example has been copied from another action. Just updating this to ensure that users don't face the same issue I did. 