### PR TITLE
Add `:` to excluded punctuation

### DIFF
--- a/src/dic.ts
+++ b/src/dic.ts
@@ -28,7 +28,7 @@ export namespace Dic {
     'outo',
   ]
 
-  export const punctuation = ['! ', ', ', ' - ', ' – ', '... ', '.. ', '. ']
+  export const punctuation = ['! ', ', ', ' - ', ' – ', '... ', '.. ', '. ', ': ']
 
   export const synonyms = {
     app: ['aplication', 'application', 'client'],


### PR DESCRIPTION
### Proposed changes

- Add colon (`:`) character in the punctuation list to be excluded