### PR TITLE
Exclude pull requests searching for duplicates

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -22,7 +22,9 @@ export namespace Action {
       })
 
       const { title } = payload
-      const issues = response.data.filter((i) => i.number !== payload.number)
+      const issues = response.data.filter(
+        (i) => i.number !== payload.number && i.pull_request === undefined,
+      )
       const threshold = parseFloat(core.getInput('threshold'))
 
       // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
Don't trigger pull requests as duplicates.

### Description

The action has marked a pull request as possible duplicated issue in https://github.com/simple-icons/simple-icons/issues/6912

[Accordingly to the octokit rest documentation](https://octokit.github.io/rest.js/v18#issues-list-for-repo), this is an expected behaviour:

> GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by the `pull_request` key.

So this change exclude pull requests searching for duplicated issues ignoring all response items for which the `pull_request` key is defined.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [ ] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.