### PR TITLE
fix: 🐛 Avoid false positives if issue title is empty after excluding

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -27,11 +27,17 @@ export namespace Action {
       )
       const threshold = parseFloat(core.getInput('threshold'))
 
+      const formattedTitle = Util.formatTitle(title)
+      if (formattedTitle === '') {
+        core.info(`Issue title "${title}" is empty after excluding words`)
+        return
+      }
+
       // eslint-disable-next-line no-restricted-syntax
       for (const issue of issues) {
         const accuracy = Algo.compare(
           Util.formatTitle(issue.title),
-          Util.formatTitle(title),
+          formattedTitle,
         )
 
         core.debug(

--- a/src/action.ts
+++ b/src/action.ts
@@ -29,7 +29,7 @@ export namespace Action {
 
       const formattedTitle = Util.formatTitle(title)
       if (formattedTitle === '') {
-        core.info(`Issue title "${title}" is empty after excluding words`)
+        core.info(`Issue title "${title}" is empty after excluding keywords`)
         return
       }
 


### PR DESCRIPTION
Don't report potential duplicates if after excluding keywords with `exclude`, the title is empty.

### Description

The action is marking the issue https://github.com/simple-icons/simple-icons/issues/7072 as a potential duplicate of all issues. We have `need` and `icon` keywords inside `exclude` option so the issue title is empty after calling `Util.formatTitle`.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [ ] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.