### PR TITLE
refactor: ♻️ Drop `isValidEvent` redundant function

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -9,11 +9,7 @@ export namespace Action {
   export async function run() {
     const { context } = github
     const payload = context.payload.issue
-    if (
-      payload &&
-      Util.isValidEvent('issues', ['opened', 'edited']) &&
-      Util.isValidTitle(payload.title)
-    ) {
+    if (payload && Util.isValidTitle(payload.title)) {
       const octokit = Util.getOctokit()
       const duplicates = []
       const response = await octokit.rest.issues.listForRepo({

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,22 +8,6 @@ export namespace Util {
     return github.getOctokit(token)
   }
 
-  export function isValidEvent(event: string, actions?: string | string[]) {
-    const { context } = github
-    const { payload } = context
-    if (event === context.eventName) {
-      if (actions == null) {
-        return true
-      }
-      if (Array.isArray(actions)) {
-        return actions.some((action) => action === payload.action)
-      }
-
-      return actions === payload.action
-    }
-    return false
-  }
-
   export function isValidTitle(title: string) {
     const filter = core.getInput('filter')
     if (filter) {


### PR DESCRIPTION
Remove `Util.isValidEvent` function.

### Description

This function is being executed before searching for duplicates, but seems to me that could lead to silent failures and does not contribute anything.

### Motivation and Context

The example in documentation suggest to use this action when issues are `opened` or `edited`. Doesn't makes sense to execute it on other contexts. So why this is being checked in the action? If at least the action would tell the user that is executing the action in an invalid event, but is not the case.

If Github changes his payload the action just runs witout noticing anything. That's the problem we're running into in [simple-icons](https://github.com/simple-icons/simple-icons), the action runs but doesn't do anything on certain issues. I'm having troubles debugging this.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [x] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [ ] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.